### PR TITLE
Add method to load all tasks of a project

### DIFF
--- a/src/Tick/Project.php
+++ b/src/Tick/Project.php
@@ -70,6 +70,17 @@ class Project
     }
 
     /**
+     * Get tasks of a specific project.
+     *
+     * @param string    $projectId  Project Id.
+     * @return mixed
+     */
+    public function getTasks($projectId)
+    {
+        return $this->client->get('projects/' . $projectId . '/tasks');
+    }
+
+    /**
      * Create project.
      *
      * @param string    $name               Project name.


### PR DESCRIPTION
It’s currently not possible to load all tasks of one project. I’ve added the method to the Project class.