### PR TITLE
WIP: Add method to ApiClient to load all entries when results are paginated

### DIFF
--- a/src/Http/ApiClient.php
+++ b/src/Http/ApiClient.php
@@ -143,6 +143,22 @@ class ApiClient implements ClientInterface
     /**
      * {@inheritdoc}
      */
+    public function getAll($endpoint, array $queryParams = [])
+    {
+        $result = [];
+        $queryParams['page'] = 1;
+
+        while ($pageResult = $this->get($endpoint, $queryParams)) {
+            $result = array_merge($result, $pageResult);
+            $queryParams['page']++;
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function post($endpoint, array $queryParams = [], array $data)
     {
         try {

--- a/src/Http/ClientInterface.php
+++ b/src/Http/ClientInterface.php
@@ -19,6 +19,16 @@ interface ClientInterface
     public function get($endpoint, array $queryParams);
 
     /**
+     * Get request for paginated results
+     *
+     * @param string    $endpoint      Final endpoint
+     * @param array     $queryParams   Parameters for querying
+     *
+     * @return mixed
+     */
+    public function getAll($endpoint, array $queryParams);
+
+    /**
      * Post Request
      *
      * @param string    $endpoint   Final endpoint


### PR DESCRIPTION
The library currently does not support paginated results and the Tick API returns only the first 100 entries. I’ve implemented a simple getAll() to load all results of possible paginated request.

If this looks reasonable to you I would replace all ApiClient::get() calls with ApiClient::getAll() where paginated results are expected.